### PR TITLE
remove peer dependency upper limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "requirejs": "~2.1.11"
   },
   "peerDependencies": {
-    "chai": ">= 1.6.1 < 2"
+    "chai": ">= 1.6.1"
   }
 }


### PR DESCRIPTION
[Chai](https://github.com/chaijs/chai) is now > 2.x.x.  Removing the peer dependency so that this can be used with the current version of chai.

I notice that on the `master` branch several of the unit tests are failing.  I have not addressed that in this PR.

