### PR TITLE
Update chai to version 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "grunt": "~0.4.2",
     "grunt-cli": "~0.1",
-    "chai": "~1.9.0",
+    "chai": "^2.0.0",
     "mocha": "~1.18.0",
     "grunt-mocha": "~0.4.10",
     "grunt-contrib-jshint": "~0.9.2",
@@ -56,6 +56,6 @@
     "requirejs": "~2.1.11"
   },
   "peerDependencies": {
-    "chai": ">= 1.6.1 < 2"
+    "chai": "^2.0.0"
   }
 }


### PR DESCRIPTION
Update to use chai 2.x as noted in https://github.com/Bartvds/chai-json-schema/issues/13

I ran the tests and there was no difference to chai 1.x.
